### PR TITLE
Use rbnacl 6.0.0 instead of now-deprecated rbnacl-libsodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: ruby
+rvm:
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 dist: xenial
 before_install:
   - scripts/build-libsodium

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 sudo: false
 language: ruby
 dist: xenial
-addons:
-  apt:
-    update: true
-    packages:
-      - libsodium18
 before_install:
-  - sudo ln -s /usr/lib/x86_64-linux-gnu/libsodium.so.18 /usr/lib/x86_64-linux-gnu/libsodium.so
+  - scripts/build-libsodium
   - gem install bundler -v 1.16.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 sudo: false
 language: ruby
-rvm:
-  - 2.3.3
-before_install: gem install bundler -v 1.16.1
+dist: xenial
+addons:
+  apt:
+    update: true
+    packages:
+      - libsodium18
+before_install:
+  - sudo ln -s /usr/lib/x86_64-linux-gnu/libsodium.so.18 /usr/lib/x86_64-linux-gnu/libsodium.so
+  - gem install bundler -v 1.16.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in paseto.gemspec
 gemspec
-
-gem 'rbnacl', :git => 'https://github.com/anirishduck/rbnacl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,22 @@
-GIT
-  remote: https://github.com/anirishduck/rbnacl
-  revision: ff58f9e5dcae0617a3ead398aadd51553c6baed1
-  specs:
-    rbnacl (5.0.0)
-      ffi
-
 PATH
   remote: .
   specs:
     paseto (0.2.0)
-      rbnacl-libsodium (~> 1.0)
+      rbnacl (~> 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     method_source (0.9.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
+    rbnacl (6.0.0)
+      ffi
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -46,7 +39,6 @@ DEPENDENCIES
   paseto!
   pry (~> 0.11)
   rake (~> 10.0)
-  rbnacl!
   rspec (~> 3.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Ruby implementation of [Paseto](https://github.com/paragonie/paseto) using [libs
 
 ## Installation
 
+To use Paseto, you will need to install [libsodium][] (at least version `1.0.0` is
+required). See [Installing libsodium][] for installation instructions.
+
 Add this line to your application's Gemfile:
 
 ```ruby
@@ -21,6 +24,9 @@ And then execute:
 Or install it yourself as:
 
     $ gem install paseto
+
+[libsodium]: https://github.com/jedisct1/libsodium
+[Installing libsodium]: https://github.com/crypto-rb/rbnacl/wiki/Installing-libsodium
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ruby implementation of [Paseto](https://github.com/paragonie/paseto) using [libs
 
 ## Installation
 
-To use Paseto, you will need to install [libsodium][] (at least version `1.0.0` is
+To use Paseto, you will need to install [libsodium][] (at least version `1.0.12` is
 required). See [Installing libsodium][] for installation instructions.
 
 Add this line to your application's Gemfile:

--- a/lib/paseto.rb
+++ b/lib/paseto.rb
@@ -1,5 +1,5 @@
 require 'base64'
-require 'rbnacl/libsodium'
+require 'rbnacl'
 
 require 'paseto/version'
 require 'paseto/error'

--- a/paseto.gemspec
+++ b/paseto.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rbnacl-libsodium', '~> 1.0'
+  spec.add_dependency 'rbnacl', '~> 6.0'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/scripts/build-libsodium
+++ b/scripts/build-libsodium
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz
+tar -zxf libsodium-1.0.16.tar.gz
+cd libsodium-1.0.16
+./configure
+make
+sudo make install


### PR DESCRIPTION
rbnacl v6.0.0 (resolves #2) was released recently. This release deprecates the use of rbnacl-libsodium (see crypto-rb/rbnacl-libsodium#29), so rbnacl now raises an error if rbnacl-libsodium is detected.

This requires the user to preinstall libsodium on their system. Paseto [works](https://github.com/crypto-rb/rbnacl/blob/v6.0.0/lib/rbnacl/aead/xchacha20poly1305_ietf.rb#L10) with libsodium >= v1.0.12.
