### PR TITLE
Fix Pre-Authentication Encoding for tokens without a footer

### DIFF
--- a/lib/paseto.rb
+++ b/lib/paseto.rb
@@ -8,6 +8,8 @@ require 'paseto/public'
 require 'paseto/local'
 
 module Paseto
+  EMPTY_FOOTER = ''.freeze
+
   # An Array#pack format to pack an unsigned little-endian 64-bit integer
   UNSIGNED_LITTLE_64 = 'Q<'.freeze
 
@@ -18,10 +20,9 @@ module Paseto
 
   # https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#pae-definition
   def self.pre_auth_encode(*pieces)
-    compacted_pieces = pieces.compact
+    initial_output = encode_length(pieces.length)
 
-    initial_output = encode_length(compacted_pieces.length)
-    compacted_pieces.reduce(initial_output) do |output, piece|
+    pieces.reduce(initial_output) do |output, piece|
       output += encode_length(piece.length)
       output += piece
     end

--- a/lib/paseto.rb
+++ b/lib/paseto.rb
@@ -8,19 +8,12 @@ require 'paseto/public'
 require 'paseto/local'
 
 module Paseto
+  # An Array#pack format to pack an unsigned little-endian 64-bit integer
+  UNSIGNED_LITTLE_64 = 'Q<'.freeze
 
   # https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#pae-definition
   def self.encode_length(n)
-    str = []
-    (0..7).each do |i|
-      # Clear the MSB for interoperability
-      n &= 127 if (i === 7)
-
-      str << (n & 255)
-      n = n >> 8
-    end
-
-    str.pack('Q')
+    [n].pack(UNSIGNED_LITTLE_64)
   end
 
   # https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#pae-definition

--- a/lib/paseto/local.rb
+++ b/lib/paseto/local.rb
@@ -24,7 +24,7 @@ module Paseto
           Paseto.encode64(@key)
         end
 
-        def encrypt(message, footer = nil)
+        def encrypt(message, footer = EMPTY_FOOTER)
           # Make a nonce: A single-use value never repeated under the same key
           nonce = generate_nonce(message)
 
@@ -36,6 +36,8 @@ module Paseto
 
         def decrypt(token, footer = nil)
           footer ||= token.footer if token.is_a? Paseto::Token
+          footer ||= EMPTY_FOOTER
+
           parsed = Paseto.verify_token(token, HEADER, footer)
 
           nonce = parsed.payload[0, NONCE_BYTES]
@@ -72,7 +74,7 @@ module Paseto
         end
       end
 
-      def self.encrypt(message, key, footer = nil)
+      def self.encrypt(message, key, footer = EMPTY_FOOTER)
         key.encrypt(message, footer)
       end
 

--- a/lib/paseto/public.rb
+++ b/lib/paseto/public.rb
@@ -28,7 +28,7 @@ module Paseto
           @nacl = RbNaCl::SigningKey.new(key)
         end
 
-        def sign(message, footer = nil)
+        def sign(message, footer = EMPTY_FOOTER)
           data = encode_message(message, footer)
           # Sign a message with the signing key
           signature = @nacl.sign(data)
@@ -67,6 +67,8 @@ module Paseto
 
         def verify(token, footer = nil)
           footer ||= token.footer if token.is_a? Paseto::Token
+          footer ||= EMPTY_FOOTER
+
           parsed = Paseto.verify_token(token, HEADER, footer)
 
           decoded_message = parsed.payload[0..-(SIGNATURE_BYTES + 1)]
@@ -84,7 +86,7 @@ module Paseto
         end
       end
 
-      def self.sign(message, key, footer = nil)
+      def self.sign(message, key, footer = EMPTY_FOOTER)
         key.sign(message, footer)
       end
 

--- a/lib/paseto/token.rb
+++ b/lib/paseto/token.rb
@@ -6,7 +6,7 @@ module Paseto
         Paseto.encode64(payload)
       ]
 
-      message << Paseto.encode64(footer) if footer
+      message << Paseto.encode64(footer) if footer && footer != EMPTY_FOOTER
 
       message.join('.')
     end
@@ -29,7 +29,7 @@ module Paseto
     version, purpose, payload, footer = raw.split('.')
 
     header = "#{version}.#{purpose}"
-    footer = Paseto.decode64(footer) unless footer.nil?
+    footer = footer.nil? ? EMPTY_FOOTER : Paseto.decode64(footer)
     payload = Paseto.decode64(payload) unless payload.nil?
 
     Token.new(header, payload, footer)

--- a/spec/paseto_spec.rb
+++ b/spec/paseto_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Paseto do
     it 'should encode a length' do
       expect(described_class.encode_length(4)).to eq("\x04\x00\x00\x00\x00\x00\x00\x00")
     end
+
+    it 'should encode numbers greater than 255' do
+      expect(described_class.encode_length(256)).to eq("\x00\x01\x00\x00\x00\x00\x00\x00")
+    end
   end
 
   describe '#pre_auth_encode' do


### PR DESCRIPTION
I stumbled upon this issue when I tried to decrypt a V2 local token encrypted using [the Elixir Paseto library](https://github.com/GrappigPanda/Paseto). If a token was encrypted without a footer, `paseto.rb` failed to decrypt it with the "Paseto::AuthenticationError: Token signature invalid" message. 

After some debugging I found out that I can work around this issue by parsing the token and setting its footer to an empty string before decrypting it.

``` rb
parsed_token = Paseto.parse(token)
parsed_token.footer ||= ''
payload = key.decrypt(parsed_token)
```

After looking at [the protocol definition](https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Version2.md) and the reference implementation, it's clear that "an optional footer" means "an empty string"; the docs are inconsistent a bit, but the reference implementation [always](https://github.com/paragonie/paseto/blob/52c094dd4f6689fa5ba5352dc3d87c0f31955f9a/src/Protocol/Version2.php#L100) [treat](https://github.com/paragonie/paseto/blob/52c094dd4f6689fa5ba5352dc3d87c0f31955f9a/src/Util.php#L138-L146) it as an empty string and doesn't accept null as a footer.

`paseto.rb` uses `nil` to represent an optional footer, which makes `Paseto#pre_auth_encode` produce incorrect results because the `nil` footers are [filtered out](https://github.com/mguymon/paseto.rb/blob/83940223507ec3562c96b1fb23e463b6438e989c/lib/paseto.rb#L28). This PR fixes it.

I have also fixed another issue: `Paseto#encode_length` correctly encodes only numbers lesser than 256; it wraps with the period of 256:

```
encode_length(0) == encode_length(256) 
                 == encode_length(512)

forall x (0 <= x < 256), n = 1,3,4..: encode_length(x * (n - 1)) == encode_length(x * n)
```

This means that `Paseto#pre_auth_encode` encodes footers longer that 255 bytes incorrectly.

