### PR TITLE
Lint with rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+require: rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 2.3
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Metrics/LineLength:
+  Max: 100
+  Exclude:
+    - "spec/**/*.rb"
+
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*.rb"
+
+Metrics/MethodLength:
+  Max: 30
+
+RSpec/ExampleLength:
+  Max: 10
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+Security/Eval:
+  Exclude:
+    - "spec/**/*.rb"
+
+Style/MultilineBlockChain:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ rvm:
 dist: xenial
 before_install:
   - scripts/build-libsodium
-  - gem install bundler -v 1.16.1
+script:
+  - bundle exec rspec
+  - bundle exec rubocop
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in paseto.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "paseto"
+require 'bundler/setup'
+require 'paseto'
 require 'pry'
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/lib/paseto.rb
+++ b/lib/paseto.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'rbnacl'
 
@@ -7,15 +9,16 @@ require 'paseto/token'
 require 'paseto/public'
 require 'paseto/local'
 
+# Platform-Agnostic SEcurity TOkens
 module Paseto
-  EMPTY_FOOTER = ''.freeze
+  EMPTY_FOOTER = ''
 
   # An Array#pack format to pack an unsigned little-endian 64-bit integer
-  UNSIGNED_LITTLE_64 = 'Q<'.freeze
+  UNSIGNED_LITTLE_64 = 'Q<'
 
   # https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#pae-definition
-  def self.encode_length(n)
-    [n].pack(UNSIGNED_LITTLE_64)
+  def self.encode_length(num)
+    [num].pack(UNSIGNED_LITTLE_64)
   end
 
   # https://github.com/paragonie/paseto/blob/master/docs/01-Protocol-Versions/Common.md#pae-definition
@@ -23,8 +26,7 @@ module Paseto
     initial_output = encode_length(pieces.length)
 
     pieces.reduce(initial_output) do |output, piece|
-      output += encode_length(piece.length)
-      output += piece
+      output + encode_length(piece.length) + piece
     end
   end
 

--- a/lib/paseto/error.rb
+++ b/lib/paseto/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Paseto
   Error = Class.new(StandardError)
   HeaderError = Class.new(Error)

--- a/lib/paseto/local.rb
+++ b/lib/paseto/local.rb
@@ -1,11 +1,15 @@
+# frozen_string_literal: true
+
 module Paseto
   module V2
+    # Symmetric Encryption
     module Local
       HEADER = 'v2.local'
       NONCE_BYTES = RbNaCl::AEAD::XChaCha20Poly1305IETF.nonce_bytes
 
       NonceError = Class.new(Paseto::Error)
 
+      # Encryption key
       class Key
         def self.generate
           new(RbNaCl::Random.random_bytes(RbNaCl::AEAD::XChaCha20Poly1305IETF.key_bytes))
@@ -43,7 +47,7 @@ module Paseto
           nonce = parsed.payload[0, NONCE_BYTES]
           ciphertext = parsed.payload[NONCE_BYTES..-1]
 
-          raise BadMessageError.new('Unable to process message') if nonce.nil? || ciphertext.nil?
+          raise BadMessageError, 'Unable to process message' if nonce.nil? || ciphertext.nil?
 
           begin
             data = additional_data(nonce, footer)
@@ -52,7 +56,7 @@ module Paseto
             raise NonceError, 'Invalid nonce'
           rescue RbNaCl::CryptoError
             raise AuthenticationError, 'Token signature invalid'
-          rescue
+          rescue StandardError
             raise TokenError, 'Unable to process message'
           end
         end

--- a/lib/paseto/token.rb
+++ b/lib/paseto/token.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Helper for verifying and parsing tokens
 module Paseto
   Token = Struct.new(:header, :payload, :footer) do
     def to_message
@@ -14,12 +17,10 @@ module Paseto
 
   def self.verify_token(token, expected_header, expected_footer)
     token = parse(token) unless token.is_a? Token
-    if token.header != expected_header
-      raise HeaderError.new("Invalid message header: #{token.header}")
-    end
+    raise HeaderError, "Invalid message header: #{token.header}" if token.header != expected_header
 
     if token.footer != expected_footer
-      raise TokenError.new("Invalid message footer: #{token.footer.inspect}")
+      raise TokenError, "Invalid message footer: #{token.footer.inspect}"
     end
 
     token

--- a/lib/paseto/version.rb
+++ b/lib/paseto/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Paseto
-  VERSION = "0.3.1"
+  VERSION = '0.3.1'
 end

--- a/paseto.gemspec
+++ b/paseto.gemspec
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'paseto/version'
 
@@ -9,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Michael Guymon', 'Frank Murphy']
   spec.email         = ['mguymon@instructure.com', 'fmurphy@instructure.com']
 
-  spec.summary       = %q{Ruby impl of Paseto}
-  spec.description   = %q{Ruby impl of Paseto}
+  spec.summary       = 'Ruby impl of Paseto'
+  spec.description   = 'Ruby impl of Paseto'
   spec.homepage      = 'https://github.com/mguymon/paseto.rb'
   spec.license       = 'MIT'
 
@@ -23,7 +24,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rbnacl', '~> 6.0'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'pry', '~> 0.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'pry', '~> 0.11'
+  spec.add_development_dependency 'rubocop', '~> 0.65'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.32'
 end

--- a/spec/paseto_spec.rb
+++ b/spec/paseto_spec.rb
@@ -1,33 +1,39 @@
+# frozen_string_literal: true
+
 RSpec.describe Paseto do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Paseto::VERSION).not_to be nil
   end
 
   describe '#encode_length' do
-    it 'should encode empty' do
+    it 'encodes empty' do
       expect(described_class.encode_length(0)).to eq("\x00\x00\x00\x00\x00\x00\x00\x00")
     end
 
-    it 'should encode a length' do
+    it 'encodes a length' do
       expect(described_class.encode_length(4)).to eq("\x04\x00\x00\x00\x00\x00\x00\x00")
     end
 
-    it 'should encode numbers greater than 255' do
+    it 'encodes numbers greater than 255' do
       expect(described_class.encode_length(256)).to eq("\x00\x01\x00\x00\x00\x00\x00\x00")
     end
   end
 
   describe '#pre_auth_encode' do
     it 'encodes an empty array' do
-      expect(described_class.pre_auth_encode()).to eq("\x00\x00\x00\x00\x00\x00\x00\x00")
+      expect(described_class.pre_auth_encode).to eq("\x00\x00\x00\x00\x00\x00\x00\x00")
     end
 
     it 'encodes an empty string' do
-      expect(described_class.pre_auth_encode('')).to eq("\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+      expect(described_class.pre_auth_encode('')).to(
+        eq("\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+      )
     end
 
     it 'encodes a string' do
-      expect(described_class.pre_auth_encode('test')).to eq("\x01\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00test")
+      expect(described_class.pre_auth_encode('test')).to(
+        eq("\x01\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00test")
+      )
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,12 @@
-require "bundler/setup"
-require "pry"
-require "paseto"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'pry'
+require 'paseto'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
Use Rubocop to lint the code as part of the Travis run. . . and, uh, turn on the actual tests in Travis.

Update style to make Rubocop happy.