### PR TITLE
CI: Try adding a GitHub Actions CI

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+
+  push:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    name: build ${{ matrix.ruby }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.6', '2.7', '3.0', '3.1', truffleruby-head ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install libsodium
+        run: scripts/build-libsodium
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Test
+        run: bundle exec rspec
+      - name: Linting
+        run: bundle exec rubocop

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: build ${{ matrix.ruby }}
+    env:
+      CODECOV: 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR is an attempt to translate the TravisCI configuration.

## To ponder

- Can we use something like `sudo apt-get install -y libsodium-dev` to get the library?